### PR TITLE
本人確認ページのフロントマークアップ

### DIFF
--- a/app/assets/stylesheets/_identity.scss
+++ b/app/assets/stylesheets/_identity.scss
@@ -1,4 +1,4 @@
-.contents{
+.single-contents{
   background-color: #fff;
   padding: 64px;
   font-size: 14px;

--- a/app/assets/stylesheets/_identity.scss
+++ b/app/assets/stylesheets/_identity.scss
@@ -3,6 +3,10 @@
   padding: 64px;
   font-size: 14px;
 
+  a{
+    color: #0099e8;
+  }
+
   p{
     margin: 8px 0 0;
   }
@@ -15,5 +19,26 @@
       width: 100%;
       margin: 8px 0 0;
     }
+    .select-wrap{
+
+      &__select{
+        @include select-default();
+        width: 100%;
+      }
+
+      i{
+        position: absolute;
+        right: 16px;
+        top: 50%;
+        color: #888;
+        font-size: 8px;
+      }
+    }
+  }
+
+  .submit-btn{
+    margin: 40px 0;
+    @include submit();
+    @include submit-red();
   }
 }

--- a/app/assets/stylesheets/_identity.scss
+++ b/app/assets/stylesheets/_identity.scss
@@ -20,18 +20,22 @@
       margin: 8px 0 0;
     }
     .select-wrap{
-
-      &__select{
-        @include select-default();
-        width: 100%;
-      }
+      position: relative;
 
       i{
+        display: inline-block;
         position: absolute;
         right: 16px;
         top: 50%;
         color: #888;
-        font-size: 8px;
+      }
+
+      &__select{
+        @include select-default();
+        width: 100%;
+        outline: 0;
+        -webkit-appearance: none;
+        -moz-appearance: none;
       }
     }
   }

--- a/app/assets/stylesheets/_identity.scss
+++ b/app/assets/stylesheets/_identity.scss
@@ -1,0 +1,19 @@
+.contents{
+  background-color: #fff;
+  padding: 64px;
+  font-size: 14px;
+
+  p{
+    margin: 8px 0 0;
+  }
+
+  &__content{
+    margin: 40px 0 0;
+
+    &__text{
+      @include input-default();
+      width: 100%;
+      margin: 8px 0 0;
+    }
+  }
+}

--- a/app/assets/stylesheets/_mypage-main.scss
+++ b/app/assets/stylesheets/_mypage-main.scss
@@ -6,6 +6,7 @@
     position: relative;
     height: 200px;
     font-size: 14px;
+    text-align: center;
 
     img{
       @include icon();

--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -35,6 +35,16 @@ body{
   text-align: right;
 }
 
+.form-arbitrary {
+  background: #ccc;
+  margin: 0 0 0 8px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  vertical-align: top;
+}
+
 @mixin clearfix() {
   &:after {
     content: '';
@@ -68,7 +78,7 @@ body{
 }
 
 @mixin user-bg(){
-  background: url("user-bg.jpg");
+  background-image: image-url('user-bg.jpg');
   background-repeat: no-repeat;
   background-size: cover;
 }

--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -81,3 +81,13 @@ body{
   border: 1px solid #ccc;
   background: #fff;
 }
+
+@mixin select-default(){
+  position: relative;
+  height: 48px;
+  padding: 0 16px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: 0;
+  font-size: 16px;
+}

--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -31,6 +31,10 @@ body{
   text-align: center;
 }
 
+.text-right{
+  text-align: right;
+}
+
 @mixin clearfix() {
   &:after {
     content: '';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@
 @import "./mypage-side-bar";
 @import "./mypage-main";
 @import "./profile";
+@import "./identity";

--- a/app/views/users/_identity.html.haml
+++ b/app/views/users/_identity.html.haml
@@ -33,8 +33,10 @@
       %label.bolb
         都道府県
       .select-wrap
-        %select{name: "prefecture", class: "select-wrap__select"}
         = icon 'fas', 'chevron-down'
+        %select{name: "prefecture", class: "select-wrap__select"}
+          %option --
+          %option 北海道
     .contents__content
       %label.bolb
         市区町村

--- a/app/views/users/_identity.html.haml
+++ b/app/views/users/_identity.html.haml
@@ -28,26 +28,37 @@
     .contents__content
       %label.bolb
         郵便番号
+      %span.form-arbitrary
+        任意
       %input{name: "zip-code", type: "text_field", placeholder: "例) 1234567", class: "contents__content__text"}
     .contents__content
       %label.bolb
         都道府県
+      %span.form-arbitrary
+        任意
       .select-wrap
         = icon 'fas', 'chevron-down'
         %select{name: "prefecture", class: "select-wrap__select"}
           %option --
           %option 北海道
+           // active_hashの利用はコンフリクトの発生を考慮して出品ページの完了後に実装
     .contents__content
       %label.bolb
         市区町村
+      %span.form-arbitrary
+        任意
       %input{name: "city", type: "text_field", placeholder: "例) 横浜市緑区", class: "contents__content__text"}
     .contents__content
       %label.bolb
         番地
+      %span.form-arbitrary
+        任意
       %input{name: "address1", type: "text_field", placeholder: "例) 青山1−1−1", class: "contents__content__text"}
     .contents__content
       %label.bolb
         建物名
+      %span.form-arbitrary
+        任意
       %input{name: "address2", type: "text_field", placeholder: "例) 柳ビル103", class: "contents__content__text"}
     %input{type: "submit", value: "登録する", class: "submit-btn"}
     %p.text-right

--- a/app/views/users/_identity.html.haml
+++ b/app/views/users/_identity.html.haml
@@ -28,8 +28,27 @@
     .contents__content
       %label.bolb
         郵便番号
-      %input{name: "zip-code", type: "text_field", placeholder: "例)1234567", class: "contents__content__text"}
+      %input{name: "zip-code", type: "text_field", placeholder: "例) 1234567", class: "contents__content__text"}
     .contents__content
       %label.bolb
         都道府県
-      %input{name: "zip-code", type: "text_field", placeholder: "例)1234567", class: "contents__content__text"}
+      .select-wrap
+        %select{name: "prefecture", class: "select-wrap__select"}
+        = icon 'fas', 'chevron-down'
+    .contents__content
+      %label.bolb
+        市区町村
+      %input{name: "city", type: "text_field", placeholder: "例) 横浜市緑区", class: "contents__content__text"}
+    .contents__content
+      %label.bolb
+        番地
+      %input{name: "address1", type: "text_field", placeholder: "例) 青山1−1−1", class: "contents__content__text"}
+    .contents__content
+      %label.bolb
+        建物名
+      %input{name: "address2", type: "text_field", placeholder: "例) 柳ビル103", class: "contents__content__text"}
+    %input{type: "submit", value: "登録する", class: "submit-btn"}
+    %p.text-right
+      = link_to "#" do
+        本人情報の登録について
+        = icon 'fas', 'chevron-right'

--- a/app/views/users/_identity.html.haml
+++ b/app/views/users/_identity.html.haml
@@ -1,0 +1,35 @@
+.mypage-main
+  %h2.chapter-head.bolb
+    本人情報の登録
+  %form.contents
+    %p
+      お客さまの本人情報をご登録ください。
+      %br
+      登録されたお名前・生年月日を変更する場合、本人確認書類の提出が必要になります。
+    %p.text-right
+      = link_to "#" do
+        本人確認書類のアップロードについて
+        = icon 'fas', 'chevron-right'
+    .contents__content
+      %label.bolb
+        お名前
+      %p
+        メルカリ花子
+    .contents__content
+      %label.bolb
+        お名前カナ
+      %p
+        メルカリハナコ
+    .contents__content
+      %label.bolb
+        生年月日
+      %p
+        YYYY/MM/DD
+    .contents__content
+      %label.bolb
+        郵便番号
+      %input{name: "zip-code", type: "text_field", placeholder: "例)1234567", class: "contents__content__text"}
+    .contents__content
+      %label.bolb
+        都道府県
+      %input{name: "zip-code", type: "text_field", placeholder: "例)1234567", class: "contents__content__text"}

--- a/app/views/users/_identity.html.haml
+++ b/app/views/users/_identity.html.haml
@@ -1,7 +1,7 @@
 .mypage-main
   %h2.chapter-head.bolb
     本人情報の登録
-  %form.contents
+  %form.single-contents
     %p
       お客さまの本人情報をご登録ください。
       %br
@@ -10,28 +10,28 @@
       = link_to "#" do
         本人確認書類のアップロードについて
         = icon 'fas', 'chevron-right'
-    .contents__content
+    .single-contents__content
       %label.bolb
         お名前
       %p
         メルカリ花子
-    .contents__content
+    .single-contents__content
       %label.bolb
         お名前カナ
       %p
         メルカリハナコ
-    .contents__content
+    .single-contents__content
       %label.bolb
         生年月日
       %p
         YYYY/MM/DD
-    .contents__content
+    .single-contents__content
       %label.bolb
         郵便番号
       %span.form-arbitrary
         任意
-      %input{name: "zip-code", type: "text_field", placeholder: "例) 1234567", class: "contents__content__text"}
-    .contents__content
+      %input{name: "zip-code", type: "text_field", placeholder: "例) 1234567", class: "single-contents__content__text"}
+    .single-contents__content
       %label.bolb
         都道府県
       %span.form-arbitrary
@@ -41,25 +41,25 @@
         %select{name: "prefecture", class: "select-wrap__select"}
           %option --
           %option 北海道
-           // active_hashの利用はコンフリクトの発生を考慮して出品ページの完了後に実装
-    .contents__content
+          // active_hashの利用はコンフリクトの発生を考慮して出品ページの完了後に実装
+    .single-contents__content
       %label.bolb
         市区町村
       %span.form-arbitrary
         任意
-      %input{name: "city", type: "text_field", placeholder: "例) 横浜市緑区", class: "contents__content__text"}
-    .contents__content
+      %input{name: "city", type: "text_field", placeholder: "例) 横浜市緑区", class: "single-contents__content__text"}
+    .single-contents__content
       %label.bolb
         番地
       %span.form-arbitrary
         任意
-      %input{name: "address1", type: "text_field", placeholder: "例) 青山1−1−1", class: "contents__content__text"}
-    .contents__content
+      %input{name: "address1", type: "text_field", placeholder: "例) 青山1−1−1", class: "single-contents__content__text"}
+    .single-contents__content
       %label.bolb
         建物名
       %span.form-arbitrary
         任意
-      %input{name: "address2", type: "text_field", placeholder: "例) 柳ビル103", class: "contents__content__text"}
+      %input{name: "address2", type: "text_field", placeholder: "例) 柳ビル103", class: "single-contents__content__text"}
     %input{type: "submit", value: "登録する", class: "submit-btn"}
     %p.text-right
       = link_to "#" do

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,3 +1,3 @@
 .wrapper
   = render "mypage-side-bar"
-  = render "profile"
+  = render "identity"


### PR DESCRIPTION
# What
本人確認ページのフロントマークアップを行う

# Why
本人確認ページのマークアップを行うことで、今後の実装を円滑にする

- Usersコントローラーにindexを仮置してビューの確認を行っている
- ヘッダー／フッターに関してはトップページ担当者が部分テンプレートとして作成中
- mypage.scss記載分は今後他部分と統一化したい
- カラーや定義などは最終的なリファクタリングで調整する予定
- 都道府県部分のactive_hashの利用は商品出品ページ担当とのコンフリクトを考慮して後から実装する予定

[![Image from Gyazo](https://i.gyazo.com/b7d2b6f6a8e850ec3865fd2a5edf839e.png)](https://gyazo.com/b7d2b6f6a8e850ec3865fd2a5edf839e)