### PR TITLE
商品出品機能の実装#3

### DIFF
--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,0 +1,16 @@
+$(function() {
+  $('.sell-main__form__content__price-first__text-field').on('keyup', function(){
+    var price = $(this).val();
+    var fee = Math.floor(price * 0.1)
+    var seller_profit = price - fee
+    
+    if (price <= 300 || price >= 9999999) {
+      $('#fee').text('-')
+      $('#seller_profit').text('-')
+    }
+    else {
+      $('#fee').text('¥' + fee.toLocaleString())
+      $('#seller_profit').text('¥' + seller_profit.toLocaleString())
+    }
+  })
+})

--- a/app/assets/stylesheets/_items_show.scss
+++ b/app/assets/stylesheets/_items_show.scss
@@ -197,11 +197,13 @@
     margin: 32px 0;
     @include submit();
     @include submit-red();
+    cursor: pointer;
   }
   .item-buy-btn-gry{
     margin: 32px 0;
     @include submit();
     @include submit-gray(100%);
+    cursor: pointer;
   }
   .item-description{
     padding: 32px 0 0;

--- a/app/assets/stylesheets/_sell.scss
+++ b/app/assets/stylesheets/_sell.scss
@@ -171,9 +171,10 @@ vertical-align: top;
         font-size: 14px;
         &__label-profit{
           font-size: 16px;
+          line-height: 45px;
         }
         &__profit{
-          font-size: 34px;
+          font-size: 30px;
         }
       }
     }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,9 +17,7 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to root_path, notice: '商品を編集しました'
-      # 詳細ページを作ったときに詳細ページに行くようにする
-      # redirect_to item_path(@item), notice: '商品を編集しました'
+      redirect_to item_path(@item), notice: '商品を編集しました'
     else
       render :edit
     end

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -21,7 +21,7 @@ class PurchaseController < ApplicationController
     customer: @card.customer_id,
     currency: 'jpy'
   )
-    if @item.update(trade_state: '売却済み', buyer_id: current_user.id)
+    if @item.update(trade_state: '取引中', buyer_id: current_user.id)
       redirect_to action: 'done'
     else
       redirect_to action: 'index'

--- a/app/views/items/_sell.html.haml
+++ b/app/views/items/_sell.html.haml
@@ -209,14 +209,14 @@
             %label
               販売手数料(10%)
           .sell-main__form__content__price__fee
-            ー
+            #fee
         //販売利益エリア↓↓↓
         %li.sell-main__form__content__price.space-between.bolb
           .sell-main__form__content__price__label-profit
             %label
               販売利益
           .sell-main__form__content__price__profit
-            ー
+            #seller_profit
     .sell-main__form__content
       %p
         %a{ href:'#' }>禁止されている出品

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -80,12 +80,12 @@
       = @item.postage
   - if user_signed_in? && current_user.id == @item.user.id
     = link_to "商品の編集", edit_item_path(@item), class: "item-buy-btn"
-    - if @item.trade_state == "出品中" then
-      = form_with model: @item, local: true, url: item_path, class: 'inner-box', loclal: true do |f|
+    - if @item.trade_state == "出品中"
+      = form_with model: @item, local: true, url: item_path, loclal: true do |f|
         = f.hidden_field :trade_state, value: "出品停止中"
         = f.submit '出品を一旦停止する', class: 'item-buy-btn-gry'
-    - elsif @item.trade_state == "出品停止中" then
-      = form_with model: @item, local: true, url: item_path, class: 'inner-box', loclal: true do |f|
+    - elsif @item.trade_state == "出品停止中"
+      = form_with model: @item, local: true, url: item_path, loclal: true do |f|
         = f.hidden_field :trade_state, value: "出品中"
         = f.submit '出品を再開する', class: 'item-buy-btn'
     = link_to 'この商品を削除する', item_path, method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-buy-btn-gry"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -80,6 +80,14 @@
       = @item.postage
   - if user_signed_in? && current_user.id == @item.user.id
     = link_to "商品の編集", edit_item_path(@item), class: "item-buy-btn"
+    - if @item.trade_state == "出品中" then
+      = form_with model: @item, local: true, url: item_path, class: 'inner-box', loclal: true do |f|
+        = f.hidden_field :trade_state, value: "出品停止中"
+        = f.submit '出品を一旦停止する', class: 'item-buy-btn-gry'
+    - elsif @item.trade_state == "出品停止中" then
+      = form_with model: @item, local: true, url: item_path, class: 'inner-box', loclal: true do |f|
+        = f.hidden_field :trade_state, value: "出品中"
+        = f.submit '出品を再開する', class: 'item-buy-btn'
     = link_to 'この商品を削除する', item_path, method: :delete, data: { confirm: '本当に削除しますか？' }, class: "item-buy-btn-gry"
   - else
     = link_to "購入画面に進む", item_purchase_index_path(@item.id), class: "item-buy-btn"


### PR DESCRIPTION
# What
商品を出品する機能を作成する#3
- 商品出品時に価格を入力した際の販売手数料と販売利益の自動計算機能を実装する
- 取引中、出品停止などの各状態の実装

# Why
商品出品は一番のメイン機能であり必須機能であるため
出品時に入力した値ですぐに手数料と利益がわかると出品者が管理しやすい
購入された場合に取引中の状態に遷移させてデータを管理しやすくするため。
出品を一次止める場合に出品停止の状態に遷移させてデータを管理しやすくするため。

# Remarks
出品中の状態にするところはLGTMもらっている。
バリデーションはLGTMもらっている。
カテゴリ、サイズのリストは仮置。機能実装は別段階にて行う。
テストについては次段階で実装する。
次段階は別のレビュー依頼を行う。